### PR TITLE
fix: Revise new SVG mockups for design consistency

### DIFF
--- a/docs/client/ui-mockups/component-showcase.svg
+++ b/docs/client/ui-mockups/component-showcase.svg
@@ -1,127 +1,96 @@
 <svg width="375" height="1200" viewBox="0 0 375 1200" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <!-- Increased height to 1200 to accommodate all components, implying scrolling -->
-  <defs>
-    <style>
-      .h1 { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 24px; font-weight: bold; fill: #0F172A; }
-      .h2 { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 20px; font-weight: bold; fill: #0F172A; margin-bottom: 12px; }
-      .body-regular { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #0F172A; }
-      .text-secondary { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #64748B; }
-      .button-text { font-family: 'Inter', 'Pretendard', sans-serif; font-weight: 500; fill: #FFFFFF; text-anchor: middle; dominant-baseline: middle;}
-      .input-text { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #0F172A; }
-      .placeholder-text { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #94A3B8; }
-    </style>
-    <filter id="card-shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
-      <feOffset dx="0" dy="2" result="offsetblur"/>
-      <feComponentTransfer>
-        <feFuncA type="linear" slope="0.5"/>
-      </feComponentTransfer>
-      <feMerge> 
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/> 
-      </feMerge>
-    </filter>
-  </defs>
-
   <!-- Background -->
   <rect width="375" height="1200" fill="#F8FAFC"/>
 
   <!-- Status Bar -->
-  <rect width="375" height="44" fill="#E2E8F0" />
-  <text x="187.5" y="28" text-anchor="middle" font-family="Inter, Pretendard, sans-serif" font-size="12px" fill="#0F172A">9:41</text>
-  <rect x="330" y="15" width="20" height="12" rx="2" stroke="#0F172A" stroke-width="1" fill="#FFFFFF"/>
-  <rect x="332" y="17" width="16" height="8" fill="#0F172A"/>
-  <rect x="305" y="15" width="18" height="12" rx="2" fill="none" stroke="#0F172A" stroke-width="1"/>
-  <line x1="308" y1="24" x2="310" y2="18" stroke="#0F172A" stroke-width="1"/>
-  <line x1="311" y1="24" x2="313" y2="20" stroke="#0F172A" stroke-width="1"/>
-  <line x1="314" y1="24" x2="316" y2="22" stroke="#0F172A" stroke-width="1"/>
+  <rect width="375" height="44" fill="#FFFFFF" />
 
   <!-- Header Area -->
   <g transform="translate(0, 44)">
-    <text x="20" y="40" class="h1">UI Components</text>
+    <text x="20" y="40" font-size="24px" font-weight="600" fill="#0F172A" dominant-baseline="middle">UI Components</text>
   </g>
 
   <!-- Main Content Area -->
   <g transform="translate(20, 120)">
 
     <!-- Buttons Section -->
-    <text y="0" class="h2">Buttons</text>
-    <g transform="translate(0, 30)">
+    <text y="0" font-size="20px" font-weight="600" fill="#0F172A">Buttons</text>
+    <g transform="translate(0, 35)">
       <!-- Primary Buttons -->
-      <rect y="0" width="335" height="48" rx="8" fill="#4F46E5"/> <!-- Indigo-600 -->
-      <text x="167.5" y="24" class="button-text" style="font-size:16px;">Primary Large (Full Width)</text>
+      <rect y="0" width="335" height="48" rx="24" fill="#2563EB"/>
+      <text x="167.5" y="24" font-size="16px" font-weight="500" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Primary Large (Full Width)</text>
       
-      <rect y="60" width="160" height="40" rx="8" fill="#4F46E5"/>
-      <text x="80" y="80" class="button-text" style="font-size:14px;">Primary Medium</text>
+      <rect y="60" width="160" height="40" rx="8" fill="#2563EB"/>
+      <text x="80" y="80" font-size="14px" font-weight="500" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Primary Medium</text>
       
-      <rect x="175" y="60" width="120" height="32" rx="8" fill="#4F46E5"/>
-      <text x="235" y="76" class="button-text" style="font-size:12px;">Primary Small</text>
+      <rect x="175" y="60" width="120" height="32" rx="8" fill="#2563EB"/>
+      <text x="235" y="76" font-size="12px" font-weight="500" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Primary Small</text>
 
       <!-- Secondary Button -->
-      <rect y="115" width="130" height="40" rx="8" fill="#E2E8F0"/> <!-- Slate-200 -->
-      <text x="65" y="135" class="button-text" style="fill:#0F172A; font-size:14px;">Secondary</text> <!-- Slate-900 text -->
+      <rect y="112" width="130" height="40" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="65" y="132" font-size="14px" font-weight="500" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">Secondary</text>
 
       <!-- Danger Button -->
-      <rect x="145" y="115" width="120" height="40" rx="8" fill="#EF4444"/> <!-- Red-500 -->
-      <text x="205" y="135" class="button-text" style="font-size:14px;">Danger Action</text>
+      <rect x="145" y="112" width="120" height="40" rx="8" fill="#EF4444"/>
+      <text x="205" y="132" font-size="14px" font-weight="500" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">Danger Action</text>
 
       <!-- Ghost Button -->
-      <rect y="170" width="130" height="40" rx="8" fill="transparent" stroke="#64748B" stroke-width="1"/> <!-- Slate-500 border -->
-      <text x="65" y="190" class="button-text" style="fill:#0F172A; font-size:14px;">Ghost Button</text>
+      <rect y="167" width="130" height="40" rx="8" fill="transparent" stroke="#64748B" stroke-width="1"/>
+      <text x="65" y="187" font-size="14px" font-weight="500" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">Ghost Button</text>
     </g>
 
     <!-- Cards Section -->
-    <text y="240" class="h2">Cards</text>
-    <g transform="translate(0, 270)">
+    <text y="245" font-size="20px" font-weight="600" fill="#0F172A">Cards</text>
+    <g transform="translate(0, 280)">
       <!-- Default Card -->
-      <rect y="0" width="335" height="100" rx="8" fill="#FFFFFF" stroke="#E2E8F0" filter="url(#card-shadow)"/>
-      <text x="15" y="20" class="body-regular" style="font-weight:bold;">Default Card</text>
-      <text x="15" y="45" class="body-regular" fill="#334155"  width="305" >This is some placeholder text for the default card. It can contain various types of content.</text>
+      <rect y="0" width="335" height="100" rx="12" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="15" y="18" font-size="14px" font-weight="600" fill="#0F172A" dominant-baseline="hanging">Default Card</text>
+      <text x="15" y="43" font-size="14px" fill="#334155" dominant-baseline="hanging">This is some placeholder text for the default card. It can contain various types of content.</text>
       
       <!-- Interactive Card -->
-      <rect y="120" width="335" height="100" rx="8" fill="#FFFFFF" stroke="#CBD5E1" filter="url(#card-shadow)" /> <!-- Slightly darker border Slate-300 -->
-      <text x="15" y="140" class="body-regular" style="font-weight:bold;">Interactive Card</text>
-      <text x="15" y="165" class="body-regular" fill="#334155">This card could have hover or active states. (Visualized with darker border)</text>
-      <text x="15" y="190" class="text-secondary" style="font-size:12px;">Note: Hover/active state implied.</text>
+      <rect y="120" width="335" height="100" rx="12" fill="#FFFFFF" stroke="#E2E8F0" />
+      <text x="15" y="138" font-size="14px" font-weight="600" fill="#0F172A" dominant-baseline="hanging">Interactive Card</text>
+      <text x="15" y="163" font-size="14px" fill="#334155" dominant-baseline="hanging">This card could have hover or active states. (Visualized with same border)</text>
+      <text x="15" y="193" font-size="12px" fill="#64748B" dominant-baseline="hanging">Note: Hover/active state implied.</text>
 
       <!-- Status Cards -->
-      <rect y="240" width="335" height="60" rx="8" fill="#ECFDF5" stroke="#A7F3D0" filter="url(#card-shadow)"/> <!-- Green-50 bg, Green-200 border -->
-      <circle cx="30" cy="270" r="8" fill="#22C55E"/> <!-- Green-500 -->
-      <text x="50" y="275" class="body-regular" fill="#065F46" style="font-weight:500;">Success Message</text> <!-- Green-800 text -->
+      <rect y="240" width="335" height="60" rx="12" fill="#ECFDF5" stroke="#A7F3D0"/>
+      <circle cx="30" cy="270" r="8" fill="#22C55E"/>
+      <text x="50" y="270" font-size="14px" font-weight="500" fill="#065F46" dominant-baseline="middle">Success Message</text>
 
-      <rect y="315" width="335" height="60" rx="8" fill="#FEF2F2" stroke="#FECACA" filter="url(#card-shadow)"/> <!-- Red-50 bg, Red-200 border -->
-      <circle cx="30" cy="345" r="8" fill="#EF4444"/> <!-- Red-500 -->
-      <text x="50" y="350" class="body-regular" fill="#991B1B" style="font-weight:500;">Error Message</text> <!-- Red-800 text -->
+      <rect y="315" width="335" height="60" rx="12" fill="#FEF2F2" stroke="#FECACA"/>
+      <circle cx="30" cy="345" r="8" fill="#EF4444"/>
+      <text x="50" y="345" font-size="14px" font-weight="500" fill="#991B1B" dominant-baseline="middle">Error Message</text>
       
-      <rect y="390" width="335" height="60" rx="8" fill="#EFF6FF" stroke="#BFDBFE" filter="url(#card-shadow)"/> <!-- Blue-50 bg, Blue-200 border -->
-      <circle cx="30" cy="420" r="8" fill="#3B82F6"/> <!-- Blue-500 -->
-      <text x="50" y="425" class="body-regular" fill="#1E40AF" style="font-weight:500;">Info Message</text> <!-- Blue-800 text -->
+      <rect y="390" width="335" height="60" rx="12" fill="#EFF6FF" stroke="#BFDBFE"/>
+      <circle cx="30" cy="420" r="8" fill="#3B82F6"/>
+      <text x="50" y="420" font-size="14px" font-weight="500" fill="#1E40AF" dominant-baseline="middle">Info Message</text>
     </g>
 
     <!-- Input Fields Section -->
-    <text y="490" class="h2">Input Fields</text>
-    <g transform="translate(0, 520)">
+    <text y="490" font-size="20px" font-weight="600" fill="#0F172A">Input Fields</text>
+    <g transform="translate(0, 525)">
       <!-- Text Input -->
-      <rect y="0" width="335" height="40" rx="6" fill="#FFFFFF" stroke="#CBD5E1"/> <!-- Slate-300 border -->
-      <text x="12" y="25" class="placeholder-text">Enter text...</text>
+      <rect y="0" width="335" height="40" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="12" y="20" font-size="14px" fill="#94A3B8" dominant-baseline="middle">Enter text...</text>
 
       <!-- Search Input -->
-      <rect y="55" width="335" height="40" rx="6" fill="#FFFFFF" stroke="#CBD5E1"/>
-      <path d="M16.5 17.5C18.9853 17.5 21 15.4853 21 13C21 10.5147 18.9853 8.5 16.5 8.5C14.0147 8.5 12 10.5147 12 13C12 15.4853 14.0147 17.5 16.5 17.5Z M19.5 19.5L22.5 22.5" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" transform="translate(5, 63)"/>
-      <text x="38" y="80" class="placeholder-text">Search...</text>
+      <rect y="55" width="335" height="40" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="15" y="75" font-size="16px" fill="#94A3B8" dominant-baseline="middle">&#x1F50D;</text>
+      <text x="40" y="75" font-size="14px" fill="#94A3B8" dominant-baseline="middle">Search...</text>
 
       <!-- Select Input -->
-      <rect y="110" width="335" height="40" rx="6" fill="#FFFFFF" stroke="#CBD5E1"/>
-      <text x="12" y="135" class="input-text">Select option...</text>
-      <path d="M8 10L12 14L16 10" stroke="#64748B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" transform="translate(300, 122)"/>
+      <rect y="110" width="335" height="40" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
+      <text x="12" y="130" font-size="14px" fill="#0F172A" dominant-baseline="middle">Select option...</text>
+      <text x="310" y="130" font-size="12px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">&#x25BC;</text>
 
       <!-- Disabled Text Input -->
-      <rect y="165" width="335" height="40" rx="6" fill="#F1F5F9" stroke="#E2E8F0"/> <!-- Slate-100 bg, Slate-200 border -->
-      <text x="12" y="190" class="placeholder-text">Disabled input</text>
+      <rect y="165" width="335" height="40" rx="8" fill="#F1F5F9" stroke="#E2E8F0"/>
+      <text x="12" y="185" font-size="14px" fill="#94A3B8" dominant-baseline="middle">Disabled input</text>
     </g>
     
     <!-- Spacer for bottom -->
-    <rect y="650" width="335" height="40" fill="transparent"/>
+    <rect y="730" width="335" height="40" fill="transparent"/>
 
   </g>
 </svg>

--- a/docs/client/ui-mockups/friend-list-screen.svg
+++ b/docs/client/ui-mockups/friend-list-screen.svg
@@ -1,59 +1,28 @@
 <svg width="375" height="812" viewBox="0 0 375 812" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <style>
-      .h1 { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 24px; font-weight: bold; fill: #0F172A; }
-      .body-large { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 16px; fill: #0F172A; }
-      .body-regular { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #0F172A; }
-      .text-secondary { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 12px; fill: #64748B; }
-      .status-text { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 12px; }
-      .button-secondary-text { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; font-weight: 500; fill: #4338CA; } /* Indigo-600 for primary action text on light bg */
-      .icon-back { fill: #0F172A; }
-      .icon-add-friend { fill: #0F172A; stroke: #0F172A; stroke-width: 2; }
-    </style>
-    <linearGradient id="online-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#22C55E;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#16A34A;stop-opacity:1" />
-    </linearGradient>
-     <linearGradient id="ingame-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3B82F6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#2563EB;stop-opacity:1" />
-    </linearGradient>
-  </defs>
-
   <!-- Background -->
   <rect width="375" height="812" fill="#F8FAFC"/>
 
   <!-- Status Bar -->
-  <rect width="375" height="44" fill="#E2E8F0" />
-  <text x="187.5" y="28" text-anchor="middle" font-family="Inter, Pretendard, sans-serif" font-size="12px" fill="#0F172A">9:41</text>
-  <!-- Mockup status bar icons -->
-  <rect x="330" y="15" width="20" height="12" rx="2" stroke="#0F172A" stroke-width="1" fill="#FFFFFF"/>
-  <rect x="332" y="17" width="16" height="8" fill="#0F172A"/>
-  <rect x="305" y="15" width="18" height="12" rx="2" fill="none" stroke="#0F172A" stroke-width="1"/>
-  <line x1="308" y1="24" x2="310" y2="18" stroke="#0F172A" stroke-width="1"/>
-  <line x1="311" y1="24" x2="313" y2="20" stroke="#0F172A" stroke-width="1"/>
-  <line x1="314" y1="24" x2="316" y2="22" stroke="#0F172A" stroke-width="1"/>
+  <rect width="375" height="44" fill="#FFFFFF" />
 
   <!-- Header Area -->
   <g transform="translate(0, 44)">
     <!-- Back Button -->
     <g transform="translate(16, 16)">
-      <path class="icon-back" d="M15.41 7.41L14 6L8 12L14 18L15.41 16.59L10.83 12L15.41 7.41Z"/>
+      <text x="0" y="13" font-size="20px" fill="#0F172A" dominant-baseline="middle">&#x2190;</text>
     </g>
     <!-- Title -->
-    <text x="50" y="29" class="h1">친구 목록</text>
+    <text x="50" y="29" font-size="24px" font-weight="600" fill="#0F172A" dominant-baseline="middle">친구 목록</text>
     <!-- Add Friend Button -->
     <g transform="translate(325, 16)">
-      <circle cx="12" cy="12" r="10" fill="none" stroke="#0F172A" stroke-width="1.5"/>
-      <line x1="12" y1="8" x2="12" y2="16" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round"/>
-      <line x1="8" y1="12" x2="16" y2="12" stroke="#0F172A" stroke-width="1.5" stroke-linecap="round"/>
+      <text x="12" y="13" font-size="24px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">&#xFF0B;</text>
     </g>
   </g>
 
   <!-- Search Bar Placeholder -->
   <rect x="20" y="110" width="335" height="40" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-  <text x="35" y="135" class="body-regular" fill="#94A3B8" dominant-baseline="middle">닉네임으로 검색</text>
-  <path d="M295 120 L300 125 L295 130" fill="none" stroke="#94A3B8" stroke-width="1.5" transform="translate(35,1)"/> <!-- Search Icon -->
+  <text x="35" y="130" font-size="14px" fill="#94A3B8" dominant-baseline="middle">닉네임으로 검색</text>
+  <text x="325" y="130" font-size="16px" fill="#94A3B8" text-anchor="middle" dominant-baseline="middle">&#x1F50D;</text>
 
 
   <!-- Friend List Area -->
@@ -61,40 +30,38 @@
     <!-- Friend Entry 1: Online -->
     <rect y="0" width="335" height="70" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
     <circle cx="35" cy="35" r="18" fill="#D1D5DB"/> <!-- Avatar Placeholder -->
-    <text x="65" y="30" class="body-large">Friend_Alpha</text>
-    <circle cx="70" cy="50" r="4" fill="url(#online-gradient)"/>
-    <text x="80" y="53" class="status-text" fill="#16A34A">온라인</text>
-    <rect x="240" y="20" width="75" height="30" rx="6" fill="#EDE9FE"/> <!-- Light purple bg for button -->
-    <text x="277.5" y="40" class="button-secondary-text" text-anchor="middle">초대</text>
+    <text x="65" y="28" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">Friend_Alpha</text>
+    <circle cx="70" cy="48" r="4" fill="#22C55E"/> <!-- Online dot -->
+    <text x="80" y="51" font-size="12px" fill="#64748B" dominant-baseline="middle">온라인</text>
+    <rect x="240" y="20" width="75" height="30" rx="6" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <text x="277.5" y="35" font-size="14px" font-weight="500" fill="#2563EB" text-anchor="middle" dominant-baseline="middle">초대</text>
 
     <!-- Friend Entry 2: Offline -->
     <rect y="80" width="335" height="70" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
     <circle cx="35" cy="115" r="18" fill="#D1D5DB"/>
-    <text x="65" y="110" class="body-large">PlayerOmega</text>
-    <circle cx="70" cy="130" r="4" fill="#9CA3AF"/> <!-- Gray for offline -->
-    <text x="80" y="133" class="status-text" fill="#6B7280">오프라인</text>
-    <rect x="240" y="100" width="75" height="30" rx="6" fill="#F3F4F6"/> <!-- Lighter gray for disabled-like button -->
-    <text x="277.5" y="120" class="button-secondary-text" fill="#9CA3AF" text-anchor="middle">초대</text>
+    <text x="65" y="108" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">PlayerOmega</text>
+    <circle cx="70" cy="128" r="4" fill="#9CA3AF"/> <!-- Offline dot -->
+    <text x="80" y="131" font-size="12px" fill="#64748B" dominant-baseline="middle">오프라인</text>
+    <rect x="240" y="100" width="75" height="30" rx="6" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <text x="277.5" y="115" font-size="14px" font-weight="500" fill="#9CA3AF" text-anchor="middle" dominant-baseline="middle">초대</text>
 
     <!-- Friend Entry 3: In Game -->
     <rect y="160" width="335" height="70" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
     <circle cx="35" cy="195" r="18" fill="#D1D5DB"/>
-    <text x="65" y="190" class="body-large">User123</text>
-    <circle cx="70" cy="210" r="4" fill="url(#ingame-gradient)"/>
-    <text x="80" y="213" class="status-text" fill="#2563EB">게임 중</text>
-    <rect x="240" y="180" width="75" height="30" rx="6" fill="#DBEAFE"/> <!-- Light blue bg for button -->
-    <text x="277.5" y="200" class="button-secondary-text" text-anchor="middle">초대</text>
+    <text x="65" y="188" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">User123</text>
+    <circle cx="70" cy="208" r="4" fill="#3B82F6"/> <!-- In Game dot -->
+    <text x="80" y="211" font-size="12px" fill="#64748B" dominant-baseline="middle">게임 중</text>
+    <rect x="240" y="180" width="75" height="30" rx="6" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <text x="277.5" y="195" font-size="14px" font-weight="500" fill="#2563EB" text-anchor="middle" dominant-baseline="middle">초대</text>
     
     <!-- Friend Entry 4: Online -->
     <rect y="240" width="335" height="70" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
     <circle cx="35" cy="275" r="18" fill="#D1D5DB"/>
-    <text x="65" y="270" class="body-large">HelperBot</text>
-    <circle cx="70" cy="290" r="4" fill="url(#online-gradient)"/>
-    <text x="80" y="293" class="status-text" fill="#16A34A">온라인</text>
-    <rect x="240" y="260" width="75" height="30" rx="6" fill="#EDE9FE"/>
-    <text x="277.5" y="280" class="button-secondary-text" text-anchor="middle">초대</text>
+    <text x="65" y="268" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">HelperBot</text>
+    <circle cx="70" cy="288" r="4" fill="#22C55E"/> <!-- Online dot -->
+    <text x="80" y="291" font-size="12px" fill="#64748B" dominant-baseline="middle">온라인</text>
+    <rect x="240" y="260" width="75" height="30" rx="6" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <text x="277.5" y="275" font-size="14px" font-weight="500" fill="#2563EB" text-anchor="middle" dominant-baseline="middle">초대</text>
   </g>
-
-  <!-- Safe Area (Bottom) -->
-  <rect y="778" width="375" height="34" fill="#E2E8F0" />
+  <!-- Safe area space is implicitly there by not drawing over it -->
 </svg>

--- a/docs/client/ui-mockups/matchmaking-screen.svg
+++ b/docs/client/ui-mockups/matchmaking-screen.svg
@@ -1,64 +1,35 @@
 <svg width="375" height="812" viewBox="0 0 375 812" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <style>
-      .h2 { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 20px; font-weight: bold; fill: #0F172A; text-anchor: middle; }
-      .body-large { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 16px; fill: #0F172A; text-anchor: middle; }
-      .body-regular { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #64748B; text-anchor: middle; }
-      .button-primary-text { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 16px; font-weight: bold; fill: #FFFFFF; text-anchor: middle; }
-      .text-secondary { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #64748B; }
-      .icon-back { fill: #0F172A; }
-    </style>
-  </defs>
-
   <!-- Background -->
   <rect width="375" height="812" fill="#F8FAFC"/>
 
   <!-- Status Bar -->
-  <rect width="375" height="44" fill="#E2E8F0" />
-  <text x="187.5" y="28" text-anchor="middle" font-family="Inter, Pretendard, sans-serif" font-size="12px" fill="#0F172A">9:41</text>
-  <!-- Mockup status bar icons -->
-  <rect x="330" y="15" width="20" height="12" rx="2" stroke="#0F172A" stroke-width="1" fill="#FFFFFF"/>
-  <rect x="332" y="17" width="16" height="8" fill="#0F172A"/>
-  <rect x="305" y="15" width="18" height="12" rx="2" fill="none" stroke="#0F172A" stroke-width="1"/>
-  <line x1="308" y1="24" x2="310" y2="18" stroke="#0F172A" stroke-width="1"/>
-  <line x1="311" y1="24" x2="313" y2="20" stroke="#0F172A" stroke-width="1"/>
-  <line x1="314" y1="24" x2="316" y2="22" stroke="#0F172A" stroke-width="1"/>
+  <rect width="375" height="44" fill="#FFFFFF" />
 
   <!-- Back Navigation -->
   <g transform="translate(16, 58)">
-    <path class="icon-back" d="M15.41 7.41L14 6L8 12L14 18L15.41 16.59L10.83 12L15.41 7.41Z"/>
-    <text x="24" y="13" class="text-secondary" style="text-anchor: start;">뒤로</text>
+    <text x="0" y="13" font-size="18px" fill="#0F172A" dominant-baseline="middle">&#x2190;</text>
+    <text x="18" y="13" font-size="14px" fill="#64748B" text-anchor="start" dominant-baseline="middle">뒤로</text>
   </g>
 
   <!-- Main Content Area (Vertically Centered) -->
-  <!-- Using a transform to roughly center content. Precise centering depends on final content height. -->
-  <g transform="translate(187.5, 406)"> <!-- Centered horizontally, and roughly vertically -->
+  <g transform="translate(187.5, 406)"> 
 
-    <!-- Search Indicator (Animated Spinner Placeholder) -->
-    <circle cx="0" cy="-120" r="30" stroke="#4F46E5" stroke-width="4" stroke-dasharray="8 4" fill="none">
-      <animateTransform attributeName="transform" type="rotate" from="0 0 -120" to="360 0 -120" dur="1s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="0" cy="-120" r="20" stroke="#A5B4FC" stroke-width="3" stroke-dasharray="6 3" fill="none">
-      <animateTransform attributeName="transform" type="rotate" from="360 0 -120" to="0 0 -120" dur="1.5s" repeatCount="indefinite"/>
-    </circle>
+    <!-- Search Indicator -->
+    <text x="0" y="-120" font-size="40px" fill="#2563EB" text-anchor="middle" dominant-baseline="middle">&#x1F504;</text>
 
     <!-- Status Message -->
-    <text y="-40" class="h2">상대방 찾는 중...</text>
+    <text y="-50" font-size="20px" font-weight="600" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">상대방 찾는 중...</text>
 
     <!-- Estimated Wait Time -->
-    <text y="0" class="body-large">예상 대기 시간: 약 1분 25초</text>
+    <text y="-10" font-size="16px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">예상 대기 시간: 약 1분 25초</text>
 
     <!-- Selected Settings Display -->
-    <text y="30" class="body-regular">게임 속도: 빠름</text>
-    <text y="50" class="body-regular">맵: 랜덤</text>
+    <text y="25" font-size="14px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">게임 속도: 빠름</text>
+    <text y="45" font-size="14px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">맵: 랜덤</text>
 
     <!-- Cancel Button -->
-    <rect x="-100" y="100" width="200" height="50" rx="8" fill="#EF4444"/> <!-- Red color for cancel -->
-    <text x="0" y="130" class="button-primary-text">매칭 취소</text>
-
+    <rect x="-100" y="100" width="200" height="50" rx="24" fill="#EF4444"/>
+    <text x="0" y="125" font-size="16px" font-weight="500" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">매칭 취소</text>
   </g>
-
-  <!-- Safe Area (Bottom) - Not strictly necessary if no bottom nav, but good for consistency -->
-  <rect y="778" width="375" height="34" fill="#E2E8F0" />
-
+  <!-- Safe area space is implicitly there by not drawing over it -->
 </svg>

--- a/docs/client/ui-mockups/profile-screen.svg
+++ b/docs/client/ui-mockups/profile-screen.svg
@@ -1,79 +1,66 @@
 <svg width="375" height="812" viewBox="0 0 375 812" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <style>
-      .h1 { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 24px; font-weight: bold; fill: #0F172A; }
-      .body-large { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 16px; fill: #0F172A; }
-      .text-secondary { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #64748B; }
-    </style>
-  </defs>
-
   <!-- Background -->
   <rect width="375" height="812" fill="#F8FAFC"/>
 
   <!-- Status Bar -->
-  <rect width="375" height="44" fill="#E2E8F0" />
-  <text x="187.5" y="28" text-anchor="middle" font-family="Inter, Pretendard, sans-serif" font-size="12px" fill="#0F172A">9:41</text>
-  <!-- Mockup status bar icons (wifi, battery) -->
-  <rect x="330" y="15" width="20" height="12" rx="2" stroke="#0F172A" stroke-width="1" fill="#FFFFFF"/>
-  <rect x="332" y="17" width="16" height="8" fill="#0F172A"/>
-  <rect x="305" y="15" width="18" height="12" rx="2" fill="none" stroke="#0F172A" stroke-width="1"/>
-  <line x1="308" y1="24" x2="310" y2="18" stroke="#0F172A" stroke-width="1"/>
-  <line x1="311" y1="24" x2="313" y2="20" stroke="#0F172A" stroke-width="1"/>
-  <line x1="314" y1="24" x2="316" y2="22" stroke="#0F172A" stroke-width="1"/>
-
+  <rect width="375" height="44" fill="#FFFFFF" />
 
   <!-- Main Content Area -->
   <g transform="translate(0, 44)">
     <!-- Title -->
-    <text x="20" y="40" class="h1">프로필</text>
+    <text x="20" y="40" font-size="24px" font-weight="600" fill="#0F172A">프로필</text>
 
     <!-- User Information Area -->
-    <rect x="20" y="80" width="335" height="80" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <rect x="20" y="80" width="335" height="80" rx="12" fill="#FFFFFF" stroke="#E2E8F0"/>
     <!-- User Icon Placeholder -->
     <circle cx="60" cy="120" r="24" fill="#D1D5DB"/>
-    <text x="100" y="120" class="body-large" dominant-baseline="middle">GUEST_12345</text>
-    <text x="100" y="140" class="text-secondary" dominant-baseline="middle">View and edit profile</text>
-
+    <text x="100" y="118" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">GUEST_12345</text>
+    <text x="100" y="138" font-size="14px" fill="#64748B" dominant-baseline="middle">View and edit profile</text>
 
     <!-- Navigation Links -->
     <g transform="translate(20, 180)">
       <!-- Statistics Card -->
       <rect y="0" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path d="M32 20 H18 V34 H32 V20ZM20 32H22V22H20V32ZM24 32H26V26H24V32ZM28 32H30V24H28V32Z" fill="#0F172A"/>
-      <text x="50" y="35" class="body-large">통계</text>
-      <text x="310" y="35" fill="#64748B" font-size="20" text-anchor="middle">&gt;</text>
+      <text x="25" y="37" font-size="20px" fill="#0F172A" text-anchor="middle">📊</text>
+      <text x="60" y="35" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">통계</text>
+      <text x="310" y="35" fill="#64748B" font-size="20px" text-anchor="middle" dominant-baseline="middle">&gt;</text>
 
       <!-- Achievements Card -->
       <rect y="70" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path d="M25 18 L22 24 L18 22 L21 28 L16 28 L19 34 L25 30 L31 34 L29 28 L34 28 L29 22 L28 24 L25 18Z" fill="#0F172A" stroke="#0F172A" stroke-width="1.5" stroke-linejoin="round"/>
-      <text x="50" y="105" class="body-large">업적</text>
-      <text x="310" y="105" fill="#64748B" font-size="20" text-anchor="middle">&gt;</text>
+      <text x="25" y="107" font-size="20px" fill="#0F172A" text-anchor="middle">🏆</text>
+      <text x="60" y="105" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">업적</text>
+      <text x="310" y="105" fill="#64748B" font-size="20px" text-anchor="middle" dominant-baseline="middle">&gt;</text>
 
       <!-- Link Account Card -->
       <rect y="140" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path d="M22 28 C20.343 28 19 29.343 19 31 C19 32.657 20.343 34 22 34 C23.657 34 25 32.657 25 31 C25 29.343 23.657 28 22 28 Z M28 22 C26.343 22 25 23.343 25 25 C25 26.657 26.343 28 28 28 C29.657 28 31 26.657 31 25 C31 23.343 29.657 22 28 22 Z M24 25.5 C24 25.224 24.224 25 24.5 25 L27.5 25 C27.776 25 28 25.224 28 25.5 C28 25.776 27.776 26 27.5 26 L24.5 26 C24.224 26 24 25.776 24 25.5 Z M26 29.5 C26 29.224 26.224 29 26.5 29 L29.5 29 C29.776 29 30 29.224 30 29.5 C30 29.776 29.776 30 29.5 30 L26.5 30 C26.224 30 26 29.776 26 29.5 Z" fill="#0F172A"/>
-      <text x="50" y="175" class="body-large">계정 연동</text>
-      <text x="310" y="175" fill="#64748B" font-size="20" text-anchor="middle">&gt;</text>
+      <text x="25" y="177" font-size="20px" fill="#0F172A" text-anchor="middle">🔗</text>
+      <text x="60" y="175" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">계정 연동</text>
+      <text x="310" y="175" fill="#64748B" font-size="20px" text-anchor="middle" dominant-baseline="middle">&gt;</text>
     </g>
   </g>
 
   <!-- Bottom Navigation Bar -->
   <rect y="734" width="375" height="44" fill="#FFFFFF" stroke="#E2E8F0"/>
   <g transform="translate(0, 734)">
-    <!-- Tab 1 (e.g., Home) -->
+    <!-- Tab 1 (Home) -->
     <rect x="0" y="0" width="93.75" height="44" fill="transparent"/>
-    <text x="46.875" y="30" text-anchor="middle" class="text-secondary">홈</text>
-    <!-- Tab 2 (e.g., Search) -->
-    <rect x="93.75" y="0" width="93.75" height="44" fill="transparent"/>
-    <text x="140.625" y="30" text-anchor="middle" class="text-secondary">검색</text>
-    <!-- Tab 3 (e.g., Notifications) -->
-    <rect x="187.5" y="0" width="93.75" height="44" fill="transparent"/>
-    <text x="234.375" y="30" text-anchor="middle" class="text-secondary">알림</text>
-    <!-- Tab 4 (Profile - Active) -->
-    <rect x="281.25" y="0" width="93.75" height="44" fill="#E0E7FF" /> <!-- Highlight for active tab -->
-    <text x="328.125" y="30" text-anchor="middle" class="body-large" style="fill: #4338CA;">프로필</text>
-  </g>
+    <text x="46.875" y="24" text-anchor="middle" font-size="12px" fill="#64748B" dominant-baseline="middle">홈</text>
+    <circle cx="46.875" cy="38" r="2.5" fill="#E2E8F0"/>
 
-  <!-- Safe Area -->
-  <rect y="778" width="375" height="34" fill="#E2E8F0" />
+    <!-- Tab 2 (Search) -->
+    <rect x="93.75" y="0" width="93.75" height="44" fill="transparent"/>
+    <text x="140.625" y="24" text-anchor="middle" font-size="12px" fill="#64748B" dominant-baseline="middle">탐색</text> 
+    <circle cx="140.625" cy="38" r="2.5" fill="#E2E8F0"/>
+
+    <!-- Tab 3 (Notifications) -->
+    <rect x="187.5" y="0" width="93.75" height="44" fill="transparent"/>
+    <text x="234.375" y="24" text-anchor="middle" font-size="12px" fill="#64748B" dominant-baseline="middle">알림</text>
+    <circle cx="234.375" cy="38" r="2.5" fill="#E2E8F0"/>
+
+    <!-- Tab 4 (Profile - Active) -->
+    <rect x="281.25" y="0" width="93.75" height="44" fill="transparent" />
+    <text x="328.125" y="24" text-anchor="middle" font-size="12px" font-weight="600" fill="#2563EB" dominant-baseline="middle">프로필</text>
+    <circle cx="328.125" cy="38" r="2.5" fill="#2563EB"/>
+  </g>
+  <!-- Safe area space is implicitly there by not drawing over it -->
 </svg>

--- a/docs/client/ui-mockups/settings-screen.svg
+++ b/docs/client/ui-mockups/settings-screen.svg
@@ -1,93 +1,80 @@
 <svg width="375" height="812" viewBox="0 0 375 812" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <style>
-      .h1 { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 24px; font-weight: bold; fill: #0F172A; }
-      .body-large { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 16px; fill: #0F172A; }
-      .text-secondary { font-family: 'Inter', 'Pretendard', sans-serif; font-size: 14px; fill: #64748B; }
-      .chevron { fill: #64748B; font-size: 20px; text-anchor: middle; }
-      .icon { fill: #0F172A; stroke-width: 1.5; stroke-linejoin: round; stroke-linecap: round; }
-    </style>
-  </defs>
-
   <!-- Background -->
   <rect width="375" height="812" fill="#F8FAFC"/>
 
   <!-- Status Bar -->
-  <rect width="375" height="44" fill="#E2E8F0" />
-  <text x="187.5" y="28" text-anchor="middle" font-family="Inter, Pretendard, sans-serif" font-size="12px" fill="#0F172A">9:41</text>
-  <!-- Mockup status bar icons -->
-  <rect x="330" y="15" width="20" height="12" rx="2" stroke="#0F172A" stroke-width="1" fill="#FFFFFF"/>
-  <rect x="332" y="17" width="16" height="8" fill="#0F172A"/>
-  <rect x="305" y="15" width="18" height="12" rx="2" fill="none" stroke="#0F172A" stroke-width="1"/>
-  <line x1="308" y1="24" x2="310" y2="18" stroke="#0F172A" stroke-width="1"/>
-  <line x1="311" y1="24" x2="313" y2="20" stroke="#0F172A" stroke-width="1"/>
-  <line x1="314" y1="24" x2="316" y2="22" stroke="#0F172A" stroke-width="1"/>
+  <rect width="375" height="44" fill="#FFFFFF" />
 
   <!-- Main Content Area -->
   <g transform="translate(0, 44)">
     <!-- Title -->
-    <text x="20" y="40" class="h1">설정</text>
+    <text x="20" y="40" font-size="24px" font-weight="600" fill="#0F172A">설정</text>
 
     <!-- Settings List -->
     <g transform="translate(20, 80)">
       <!-- 계정 (Account) -->
       <rect y="0" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path class="icon" d="M25 22 C27.7614 22 30 19.7614 30 17 C30 14.2386 27.7614 12 25 12 C22.2386 12 20 14.2386 20 17 C20 19.7614 22.2386 22 25 22 Z M18 30 C18 26.6863 21.134 24 25 24 C28.866 24 32 26.6863 32 30 V31 H18 V30 Z" transform="translate(0, 15)"/>
-      <text x="50" y="35" class="body-large">계정</text>
-      <text x="310" y="35" class="chevron">&gt;</text>
+      <text x="30" y="35" font-size="20px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">👤</text>
+      <text x="60" y="35" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">계정</text>
+      <text x="310" y="35" font-size="20px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">&gt;</text>
 
       <!-- 알림 (Notifications) -->
       <rect y="70" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path class="icon" d="M20 20 H30 C30 20 28 16 25 16 C22 16 20 20 20 20 Z M18 20 H32 V22 H18 V20 Z M25 28 C26.6569 28 28 26.6569 28 25 L22 25 C22 26.6569 23.3431 28 25 28 Z" transform="translate(0, 85)"/>
-      <text x="50" y="105" class="body-large">알림</text>
-      <text x="310" y="105" class="chevron">&gt;</text>
+      <text x="30" y="105" font-size="20px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">🔔</text>
+      <text x="60" y="105" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">알림</text>
+      <text x="310" y="105" font-size="20px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">&gt;</text>
 
       <!-- 게임 설정 (Game Settings) -->
       <rect y="140" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path class="icon" d="M25,16 A2,2 0 0,0 23.4,17.2 L22.8,19.4 A5.5,5.5 0 0,0 20.5,20.5 L18.3,20 L17.2,21.4 A2,2 0 0,0 16,23 L16,27 A2,2 0 0,0 17.2,28.6 L18.3,29.9 L20.5,29.4 A5.5,5.5 0 0,0 22.8,30.6 L23.4,32.8 A2,2 0 0,0 25,34 L29,34 A2,2 0 0,0 30.6,32.8 L31.2,30.6 A5.5,5.5 0 0,0 33.5,29.5 L35.7,30 L36.8,28.6 A2,2 0 0,0 38,27 L38,23 A2,2 0 0,0 36.8,21.4 L35.7,20.1 L33.5,20.6 A5.5,5.5 0 0,0 31.2,19.4 L30.6,17.2 A2,2 0 0,0 29,16 L25,16 Z M27,25 A3,3 0 1,1 27,31 A3,3 0 0,1 27,25 Z" transform="translate(-2, 155)"/>
-      <text x="50" y="175" class="body-large">게임 설정</text>
-      <text x="310" y="175" class="chevron">&gt;</text>
+      <text x="30" y="175" font-size="20px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">⚙️</text>
+      <text x="60" y="175" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">게임 설정</text>
+      <text x="310" y="175" font-size="20px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">&gt;</text>
 
       <!-- 화면 모드 (Display Mode) -->
       <rect y="210" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path class="icon" d="M25 15 C19.4772 15 15 19.4772 15 25 C15 30.5228 19.4772 35 25 35 C27.7302 35 30.2135 33.9897 32 32.3028 C30.5971 32.7354 29.0901 33 27.5 33 C21.1487 33 16 27.8513 16 21.5 C16 17.9369 18.0593 14.8458 21.0038 13.1061 C20.0013 14.1371 19.6667 15 19.6667 15 L25 15Z" transform="translate(-2, 225)"/>
-      <text x="50" y="245" class="body-large">화면 모드</text>
+      <text x="30" y="245" font-size="20px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">🌙</text>
+      <text x="60" y="245" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">화면 모드</text>
       <!-- Toggle Switch -->
-      <rect x="280" y="225" width="40" height="20" rx="10" fill="#E2E8F0"/>
-      <circle cx="290" cy="235" r="8" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="1"/>
-      <!-- <circle cx="310" cy="235" r="8" fill="#4F46E5"/> toggle on state -->
+      <rect x="275" y="228" width="50" height="24" rx="12" fill="#E2E8F0"/> <!-- Off state fill -->
+      <circle cx="287" cy="240" r="8" fill="#FFFFFF"/> <!-- Knob for off state -->
+      <!-- For 'On' state: fill="#2563EB" for rect, cx="313" for circle -->
 
       <!-- 도움말 (Help) -->
       <rect y="280" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path class="icon" d="M25 16 A9 9 0 0 0 16 25 C16 28.0363 17.6649 30.7003 20 32.4014 V35 H30 V32.4014 C32.3351 30.7003 34 28.0363 34 25 A9 9 0 0 0 25 16 Z M25 29 C24.4477 29 24 28.5523 24 28 V27 H26 V28 C26 28.5523 25.5523 29 25 29 Z M25 20 C23.3431 20 22 21.3431 22 23 C22 23.8284 22.3358 24.5784 22.8787 25.1213 C23.4216 25.6642 24.1716 26 25 26 C26.6569 26 28 24.6569 28 23 C28 21.3431 26.6569 20 25 20 Z" transform="translate(0, 295)"/>
-      <text x="50" y="315" class="body-large">도움말</text>
-      <text x="310" y="315" class="chevron">&gt;</text>
+      <text x="30" y="315" font-size="20px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">❓</text>
+      <text x="60" y="315" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">도움말</text>
+      <text x="310" y="315" font-size="20px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">&gt;</text>
 
       <!-- 정보 (About) -->
       <rect y="350" width="335" height="60" rx="8" fill="#FFFFFF" stroke="#E2E8F0"/>
-      <path class="icon" d="M25 16 C20.0294 16 16 20.0294 16 25 C16 29.9706 20.0294 34 25 34 C29.9706 34 34 29.9706 34 25 C34 20.0294 29.9706 16 25 16 Z M24 20 H26 V22 H24 V20 Z M24 24 H26 V29 H24 V24 Z" transform="translate(0, 365)"/>
-      <text x="50" y="385" class="body-large">정보</text>
-      <text x="310" y="385" class="chevron">&gt;</text>
+      <text x="30" y="385" font-size="20px" fill="#0F172A" text-anchor="middle" dominant-baseline="middle">ℹ️</text>
+      <text x="60" y="385" font-size="16px" font-weight="500" fill="#0F172A" dominant-baseline="middle">정보</text>
+      <text x="310" y="385" font-size="20px" fill="#64748B" text-anchor="middle" dominant-baseline="middle">&gt;</text>
     </g>
   </g>
 
   <!-- Bottom Navigation Bar -->
   <rect y="734" width="375" height="44" fill="#FFFFFF" stroke="#E2E8F0"/>
   <g transform="translate(0, 734)">
-    <!-- Tab 1 (e.g., Home) -->
+    <!-- Tab 1 (Home) -->
     <rect x="0" y="0" width="93.75" height="44" fill="transparent"/>
-    <text x="46.875" y="30" text-anchor="middle" class="text-secondary">홈</text>
-    <!-- Tab 2 (e.g., Search) -->
-    <rect x="93.75" y="0" width="93.75" height="44" fill="transparent"/>
-    <text x="140.625" y="30" text-anchor="middle" class="text-secondary">검색</text>
-    <!-- Tab 3 (e.g., Notifications) -->
-    <rect x="187.5" y="0" width="93.75" height="44" fill="transparent"/>
-    <text x="234.375" y="30" text-anchor="middle" class="text-secondary">알림</text>
-    <!-- Tab 4 (Profile - Active, assuming Settings is part of Profile flow) -->
-    <rect x="281.25" y="0" width="93.75" height="44" fill="#E0E7FF" />
-    <text x="328.125" y="30" text-anchor="middle" class="body-large" style="fill: #4338CA;">프로필</text>
-  </g>
+    <text x="46.875" y="24" text-anchor="middle" font-size="12px" fill="#64748B" dominant-baseline="middle">홈</text>
+    <circle cx="46.875" cy="38" r="2.5" fill="#E2E8F0"/>
 
-  <!-- Safe Area -->
-  <rect y="778" width="375" height="34" fill="#E2E8F0" />
+    <!-- Tab 2 (Friends) -->
+    <rect x="93.75" y="0" width="93.75" height="44" fill="transparent"/>
+    <text x="140.625" y="24" text-anchor="middle" font-size="12px" fill="#64748B" dominant-baseline="middle">친구</text> 
+    <circle cx="140.625" cy="38" r="2.5" fill="#E2E8F0"/>
+
+    <!-- Tab 3 (Lobby) -->
+    <rect x="187.5" y="0" width="93.75" height="44" fill="transparent"/>
+    <text x="234.375" y="24" text-anchor="middle" font-size="12px" fill="#64748B" dominant-baseline="middle">로비</text>
+    <circle cx="234.375" cy="38" r="2.5" fill="#E2E8F0"/>
+
+    <!-- Tab 4 (Settings - Active) -->
+    <rect x="281.25" y="0" width="93.75" height="44" fill="transparent" />
+    <text x="328.125" y="24" text-anchor="middle" font-size="12px" font-weight="600" fill="#2563EB" dominant-baseline="middle">설정</text>
+    <circle cx="328.125" cy="38" r="2.5" fill="#2563EB"/>
+  </g>
+  <!-- Safe area space is implicitly there by not drawing over it -->
 </svg>


### PR DESCRIPTION
This commit updates five recently added SVG mockups to address design inconsistencies identified in your feedback. The goal was to align these mockups more closely with the visual style of existing reference mockups and the definitions in `docs/client/ui-ux-design.md`.

Revised files:
- docs/client/ui-mockups/profile-screen.svg
- docs/client/ui-mockups/settings-screen.svg
- docs/client/ui-mockups/matchmaking-screen.svg
- docs/client/ui-mockups/friend-list-screen.svg
- docs/client/ui-mockups/component-showcase.svg

Key changes across these files include:
- Converted styling from CSS classes to inline attributes.
- Simplified icons to Unicode characters or basic shapes.
- Standardized status bar and safe area treatments.
- Corrected font weights, corner radii, and color usage for buttons, cards, and other UI elements to match established patterns.
- Removed non-reference visual effects like gradients and SVG-defined shadows.
- Ensured component details (e.g., toggle switches, bottom navigation) match reference implementations.

These changes aim to provide a more cohesive and consistent set of UI mockups for the project.